### PR TITLE
Adjust "start" script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "nest build -- -b swc",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "node dist/main",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",


### PR DESCRIPTION
The "start" script in package.json has been modified to execute the compiled application using node. This change allows the application to run from the 'dist' directory, which is the output of the building process.