### PR TITLE
Update postinstall script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "nest build -- -b swc",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "postinstall": "npx prisma generate && yarn build",
+    "postinstall": "prisma migrate deploy && yarn build",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",


### PR DESCRIPTION
The postinstall script command in package.json has been changed from "npx prisma generate" to "prisma migrate deploy".