### PR TITLE
fix/

### DIFF
--- a/src/modules/admin/admins.controller.ts
+++ b/src/modules/admin/admins.controller.ts
@@ -39,7 +39,6 @@ export class AdminsController {
   @ApiConflictResponse({
     description: 'This email already exists',
   })
-  @UseGuards(JwtGuard)
   create(@Body() createAdminDto: CreateAdminDto) {
     return this.adminsService.create(createAdminDto);
   }


### PR DESCRIPTION
Remove JwtGuard decorator from create method

The JwtGuard decorator is removed from the create method within the admins.controller.ts file. This may affect authorization for the create admin functionality, ensuring that it can be accessed without the need of a JWT token.